### PR TITLE
Update Mongo to 4.1.3-xenial

### DIFF
--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -1,1 +1,1 @@
-FROM mongo:4.0-xenial
+FROM mongo:4.1.3-xenial


### PR DESCRIPTION
This is staying with xenial. Research should be done to figure out the differences of the tags:

https://hub.docker.com/r/library/mongo/tags/